### PR TITLE
Fixed a small bug

### DIFF
--- a/gal_data.py
+++ b/gal_data.py
@@ -57,21 +57,16 @@ def gal_data(names=None, data=None, all=False, data_dir=None, tag=None):
     # NAME OR NAMES of GALAXIES
     if type(names) == str:
         names = [names]
-    # keep = np.zeros(len(data), dtype=bool)
     indices = []
 
     # SEARCH FOR GALAXIES
     for name in names:
         name_a = aliases[name.replace(' ', '').upper()]
-        # ind = data.field('NAME') == name_a
         ind = np.where(data.field('NAME') == name_a)[0]
 
-        # if sum(ind) == 0:
         if len(ind) == 0:
             print('No match for ' + name)
         else:
-            # keep += ind
             indices += ind.tolist()
 
-    # return data[keep]
     return data[(indices,)]

--- a/gal_data.py
+++ b/gal_data.py
@@ -57,16 +57,21 @@ def gal_data(names=None, data=None, all=False, data_dir=None, tag=None):
     # NAME OR NAMES of GALAXIES
     if type(names) == str:
         names = [names]
-    keep = np.zeros(len(data), dtype=bool)
+    # keep = np.zeros(len(data), dtype=bool)
+    indices = []
 
     # SEARCH FOR GALAXIES
     for name in names:
         name_a = aliases[name.replace(' ', '').upper()]
-        ind = data.field('NAME') == name_a
+        # ind = data.field('NAME') == name_a
+        ind = np.where(data.field('NAME') == name_a)[0]
 
-        if sum(ind) == 0:
+        # if sum(ind) == 0:
+        if len(ind) == 0:
             print('No match for ' + name)
         else:
-            keep += ind
+            # keep += ind
+            indices += ind.tolist()
 
-    return data[keep]
+    # return data[keep]
+    return data[(indices,)]


### PR DESCRIPTION
When querying galbase for several galaxies at the same time, e.g:
`>>> data = gal_data(('ngc4303', 'ngc0628', 'ngc4535'))`
the order of the rows in the output data structure is not the same as the order of the input, e.g.:
`>>> data['NAME']`
`chararray(['NGC0628', 'NGC4303', 'NGC4535'],
          dtype='<U28')`

I am proposing a way to fix this bug.